### PR TITLE
Dont force color black if none provided

### DIFF
--- a/lib/src/theme/filter_list_delegate_theme.dart
+++ b/lib/src/theme/filter_list_delegate_theme.dart
@@ -44,8 +44,7 @@ class FilterListDelegateThemeData with Diagnosticable {
     tileTextStyle = tileTextStyle ??
         const TextStyle(
           fontSize: 16,
-          fontWeight: FontWeight.w500,
-          color: Colors.black,
+          fontWeight: FontWeight.w500
         );
 
     listTileTheme ??= const ListTileThemeData();


### PR DESCRIPTION
This force user to implement a full textStyle.
if no color provided Flutter should automatically use the colorScheme.onSurface 