### PR TITLE
Result list should be calculated from the tempList not the initial one

### DIFF
--- a/lib/src/filter_list_delegate.dart
+++ b/lib/src/filter_list_delegate.dart
@@ -271,7 +271,7 @@ One of the tileLabel or suggestionBuilder is required
           builder: (BuildContext innerContext) {
             final state = StateProvider.of<FilterState<T>>(innerContext);
             return ListView.builder(
-              itemCount: state.items!.length,
+              itemCount: tempList!.length,
               itemBuilder: (context, index) {
                 final theme = FilterListDelegateTheme.of(innerContext);
                 final item = tempList[index];


### PR DESCRIPTION
in `FilterListDelegate` the lenght is always defined based on the initial list instead of using the temporary (filtered) one, causing a. `RangeError` 

![Capture d’écran 2025-02-24 à 11 14 31](https://github.com/user-attachments/assets/4b029598-5543-43ac-8a51-ca523a3b5622)
